### PR TITLE
Fix project.scripts (#9) due to cli_legacy.py rename (dd316f39)

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -13,7 +13,7 @@ for file, size, p, t in [
     for thickness in [0, t]:
         for mode in ["nearest", "bicubic", "center", "k-centroid", "contrast"]:
             all_command.append(
-                "python -m pixeloe.cli "
+                "python -m pixeloe.cli_legacy "
                 f"{file} --thickness {thickness} "
                 f"--target_size {size} --patch_size {p} "
                 f"-M {mode} -O {output_file}-t{thickness}-{mode}.webp"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,8 @@ dependencies = [
 Homepage = "https://github.com/KohakuBlueleaf/PixelOE"
 
 [project.scripts]
-"pixeloe.pixelize" = "pixeloe.cli:pixelize"
-"pixeloe.outline" = "pixeloe.cli:outline"
+"pixeloe.pixelize" = "pixeloe.cli_legacy:pixelize"
+"pixeloe.outline" = "pixeloe.cli_legacy:outline"
 
 [tool.setuptools]
 package-dir = {"" = "src"}


### PR DESCRIPTION
Fix project.scripts due to cli_legacy.py rename (dd316f39), this should also fix #9 