### PR TITLE
fix TypeError in PreResize node

### DIFF
--- a/nodes/pixel.py
+++ b/nodes/pixel.py
@@ -11,6 +11,7 @@ import torch
 from pixeloe.torch.pixelize import pixelize
 from pixeloe.torch.outline import outline_expansion
 from pixeloe.torch.utils import pre_resize
+from torchvision.transforms.functional import to_pil_image
 
 
 # Constants
@@ -154,11 +155,12 @@ class PreResize:
         device: str,
     ):
         img, use_channel_last, org_device = image_preprocess(img, device)
+        img = to_pil_image(img[0])
         img = pre_resize(img, target_size=target_pixels, patch_size=pixel_size)
         img = img.to(org_device)
         if use_channel_last:
             img = img.permute(0, 2, 3, 1)
-        return img
+        return (img,)
 
 
 NODE_CLASS_MAPPINGS = {


### PR DESCRIPTION
`image_preprocess()` return torch.Tensor but `pre_resize()` expects get PIL.Image, this will cause a error

```
!!! Exception during processing !!! cannot unpack non-iterable builtin_function_or_method object
Traceback (most recent call last):
  File "E:\Softwares\ComfyUI\execution.py", line 327, in execute
    output_data, output_ui, has_subgraph = get_output_data(obj, input_data_all, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb)
                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "E:\Softwares\ComfyUI\execution.py", line 202, in get_output_data
    return_values = _map_node_over_list(obj, input_data_all, obj.FUNCTION, allow_interrupt=True, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "E:\Softwares\ComfyUI\execution.py", line 174, in _map_node_over_list
    process_inputs(input_dict, i)
  File "E:\Softwares\ComfyUI\execution.py", line 163, in process_inputs
    results.append(getattr(obj, func)(**inputs))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "E:\Softwares\ComfyUI\custom_nodes\PixelOE\nodes\pixel.py", line 157, in execute
    img = pre_resize(img, target_size=target_pixels, patch_size=pixel_size)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "E:\Softwares\ComfyUI\venv\Lib\site-packages\pixeloe\torch\utils.py", line 68, in pre_resize
    W, H = img_pil.size
    ^^^^
TypeError: cannot unpack non-iterable builtin_function_or_method object
```

use `to_pil_image()` transfer torch.Tensor to PIL.Image for `pre_resize()` can fix it and PreResize node works well